### PR TITLE
Add snapped example of cpa_sample_code

### DIFF
--- a/snaps/cpa-sample-code/README.md
+++ b/snaps/cpa-sample-code/README.md
@@ -1,0 +1,56 @@
+# Snapped CPA Sample Code Command
+
+**NOTE**: as of Aug 6 2024 this snap requires a custom build of snapd
+containing the `intel-qat` interface.
+
+## Building the snap
+
+First install the `snapcraft` snap if you have not already:
+
+```
+sudo snap install --classic snapcraft
+lxd init --auto
+```
+
+Now you can build snapped [cpa_sample_code](https://intel.github.io/quickassist/qatlib/sample_code.html?highlight=cpa_sample#running-the-sample-code):
+
+```
+snapcraft
+```
+
+## Installing the snap
+
+```
+sudo snap install --dangerous cpa-sample-code-snap_24.02.0_amd64.snap
+```
+
+## Connecting to the snap interface
+
+To access QAT resources on the host, connect to the interface with:
+
+```
+sudo snap connect cpa-sample-code-snap:intel-qat
+```
+
+The application also needs to create threads, set task affinity, and
+perform other process control tasks. Connect to the `process-control`
+interface in order to obtain permissions for these tasks:
+
+```
+sudo snap connect cpa-sample-code-snap:process-control
+```
+
+## Running the snap
+
+Note the application takes several minutes to complete. Runtime
+parameters for the application can be found [here](https://intel.github.io/quickassist/GSG/2.X/sampleapplications.html#qat-2-0-gsg-sample-code-parameters).
+
+```
+cpa-sample-code-snap
+```
+
+To run with `strace`:
+
+```
+snap run --strace="-e trace=openat" cpa-sample-code-snap
+```

--- a/snaps/cpa-sample-code/snapcraft.yaml
+++ b/snaps/cpa-sample-code/snapcraft.yaml
@@ -22,3 +22,7 @@ parts:
   openssl:
     plugin: nil
     stage-packages: [qatlib-examples]
+
+layout:
+  /usr/share/qat:
+    bind: $SNAP/usr/share/qat

--- a/snaps/cpa-sample-code/snapcraft.yaml
+++ b/snaps/cpa-sample-code/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: cpa-sample-code-snap
+base: core24
+version: '24.02.0'
+summary: CPA sample code snap
+description: |
+  CPA sample application that uses qatlib.
+grade: devel
+confinement: strict
+
+plugs:
+  intel-qat:
+    interface: intel-qat
+  process-control:
+    interface: process-control
+
+apps:
+  cpa-sample-code-snap:
+    plugs: [intel-qat, process-control]
+    command: usr/bin/cpa_sample_code
+
+parts:
+  openssl:
+    plugin: nil
+    stage-packages: [qatlib-examples]


### PR DESCRIPTION
This adds a `snapcraft.yaml` for building [cpa_sample_code](https://intel.github.io/quickassist/qatlib/sample_code.html?highlight=cpa_sample#running-the-sample-code) inside a snap and connecting to the `intel-qat` snap interface.

I've tested this in both managed mode and standalone mode.